### PR TITLE
Add support for Negative Binomial model for count outcomes in BIVA.

### DIFF
--- a/R/biva.R
+++ b/R/biva.R
@@ -36,6 +36,7 @@ biva <- R6::R6Class(
     ..beta_ymodel = NULL,
     ..beta_smodel = NULL,
     ..sigma = NULL,
+    ..phi = NULL,
     ..strata_prob = NULL,
     ..mean_outcome = NULL,
     ..CACE_draws = NULL,
@@ -73,8 +74,10 @@ biva <- R6::R6Class(
     #' @param beta_sd_ymodel The prior standard deviations for coefficients in the Y-models including intercept (numeric matrix; dimension = # outcome models x # covariates)
     #' @param beta_mean_smodel The prior means for coefficients in the S-models including intercept (numeric matrix; dimension = (# strata - 1) x # covariates)
     #' @param beta_sd_smodel The prior standard deviations for coefficients in the S-models including intercept (numeric matrix; dimension = (# strata - 1) x # covariates)
-    #' @param sigma_shape_ymodel The prior shape for standard deviation of errors in the Y-models (numeric vector; length = # outcome models)
-    #' @param sigma_scale_ymodel The prior scale for standard deviation of errors in the Y-models (numeric vector; length = # outcome models)
+    #' @param sigma_shape_ymodel The prior shape for standard deviation of errors in the Y-models (numeric vector; length = # outcome models). Only used if y_type == "real".
+    #' @param sigma_scale_ymodel The prior scale for standard deviation of errors in the Y-models (numeric vector; length = # outcome models). Only used if y_type == "real".
+    #' @param phi_shape_ymodel The prior shape for dispersion parameter in the Y-models (numeric vector; length = # outcome models). Only used if y_type == "count".
+    #' @param phi_rate_ymodel The prior rate for dispersion parameter in the Y-models (numeric vector; length = # outcome models). Only used if y_type == "count".
     #' @param seed Seed for Stan fitting
     #' @param fit Flag for fitting the data to the model or not (1 if fit, 0 otherwise)
     #' @param ... Additional arguments for Stan
@@ -89,8 +92,10 @@ biva <- R6::R6Class(
                           beta_sd_ymodel,
                           beta_mean_smodel,
                           beta_sd_smodel,
-                          sigma_shape_ymodel,
-                          sigma_scale_ymodel,
+                          sigma_shape_ymodel = NULL,
+                          sigma_scale_ymodel = NULL,
+                          phi_shape_ymodel = NULL,
+                          phi_rate_ymodel = NULL,
                           seed = 1997,
                           fit = TRUE,
                           ...) {
@@ -184,6 +189,28 @@ biva <- R6::R6Class(
           beta_sd_smodel = beta_sd_smodel,
           run_estimation = 0
         )
+      } else if (y_type == "count") {
+        # New stan_data block for count
+        stan_data <- list(
+          N = cleaned_data$N,
+          P_ymodel = cleaned_data$P_ymodel,
+          P_smodel = cleaned_data$P_smodel,
+          Z = cleaned_data$Z,
+          D = cleaned_data$D,
+          Y = cleaned_data$Y,
+          X_ymodel = cleaned_data$X_ymodel,
+          X_smodel = cleaned_data$X_smodel,
+          ER = ER,
+          K_ymodel = cleaned_data$K_ymodel,
+          K_smodel = cleaned_data$K_smodel,
+          beta_mean_ymodel = beta_mean_ymodel,
+          beta_sd_ymodel = beta_sd_ymodel,
+          beta_mean_smodel = beta_mean_smodel,
+          beta_sd_smodel = beta_sd_smodel,
+          phi_shape_ymodel = phi_shape_ymodel,
+          phi_rate_ymodel = phi_rate_ymodel,
+          run_estimation = 0
+        )
       }
 
       private$..stan_data <- stan_data
@@ -194,6 +221,10 @@ biva <- R6::R6Class(
         )
       } else if (y_type == "binary") {
         sim_out <- rstan::sampling(stanmodels$logistic,
+          data = private$..stan_data
+        )
+      } else if (y_type == "count") {
+        sim_out <- rstan::sampling(BIVA.models::negbin,
           data = private$..stan_data
         )
       }
@@ -231,6 +262,10 @@ biva <- R6::R6Class(
           private$..stanfit <- rstan::sampling(stanmodels$logistic,
             data = stan_data, ...
           )
+        } else if (y_type == "count") {
+          private$..stanfit <- rstan::sampling(BIVA.models::negbin,
+            data = stan_data, ...
+          )
         }
 
         private$..mcmc_checks <- imt::mcmcChecks$new(
@@ -247,6 +282,9 @@ biva <- R6::R6Class(
         if (y_type == "real") {
           private$..sigma <-
             rstan::extract(private$..stanfit)$"sigma"
+        } else if (y_type == "count") {
+          private$..phi <-
+            rstan::extract(private$..stanfit)$"phi"
         }
 
         private$..strata_prob <-
@@ -836,6 +874,18 @@ biva <- R6::R6Class(
             lin_pred <- cbind(1, as.matrix(X)) %*% t(as.matrix(beta_ymodel))
             prob <- 1 / (1 + exp(-lin_pred))
             return(prob)
+          },
+          X = X_spred, N = N
+        )
+      } else if (private$..y_type == "count") {
+        y_sim <- purrr::pmap(
+          .l = list(
+            beta_ymodel = purrr::array_branch(private$..beta_ymodel, 1)
+          ),
+          .f = function(beta_ymodel, X, N) {
+            lin_pred <- cbind(1, as.matrix(X)) %*% t(as.matrix(beta_ymodel))
+            # For Negative Binomial with log link, the expected mean is exp(linear_predictor)
+            return(exp(lin_pred))
           },
           X = X_spred, N = N
         )

--- a/inst/stan/negbin.stan
+++ b/inst/stan/negbin.stan
@@ -1,0 +1,276 @@
+/*
+# Copyright 2024 Google LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/
+
+data {
+    // The number of observations
+    int<lower=0> N;
+    // The number of covariates in the Y-models
+    int<lower=0> P_ymodel;
+    // The number of covariates in the S-models
+    int<lower=0> P_smodel;
+    // The treatment assigned vector (binary instrument variable)
+    int<lower=0, upper=1> Z[N];
+    // The treatment received vector (binary treatment variable)
+    int<lower=0, upper=1> D[N];
+    // The dependent variable vector (count outcome variable)
+    int<lower=0> Y[N];
+    // The covariate matrix in the Y-models (including intercept after data cleaning)
+    matrix[N, P_ymodel] X_ymodel;
+    // The covariate matrix in the S-models (including intercept after data cleaning)
+    matrix[N, P_smodel] X_smodel;
+    // The assumption of exclusion restriction (ER = 1 if assumed)
+    int<lower=0, upper=1> ER;
+    // The number of Y-models
+    int<lower=3, upper=6> K_ymodel;
+    // The number of S-models (equal to the number of noncompliance sides)
+    int<lower=1, upper=2> K_smodel;
+    // The prior means for coefficients in the Y-models (including intercept)
+    matrix[K_ymodel, P_ymodel] beta_mean_ymodel;
+    // The prior standard deviations for coefficients in the Y-models (including intercept)
+    matrix[K_ymodel, P_ymodel] beta_sd_ymodel;
+    // The prior means for coefficients in the S-models (including intercept)
+    matrix[K_smodel, P_smodel] beta_mean_smodel;
+    // The prior standard deviations for coefficients in the S-models (including intercept)
+    matrix[K_smodel, P_smodel] beta_sd_smodel;
+    // The prior shape for the dispersion parameter (phi) in Y-models
+    real phi_shape_ymodel[K_ymodel];
+    // The prior rate for the dispersion parameter (phi) in Y-models
+    real<lower=0> phi_rate_ymodel[K_ymodel];
+    // Flag for running estimation (0: no, 1: yes)
+    int<lower=0, upper=1> run_estimation;
+}
+
+transformed data {
+    // S[k] indexes Y-model [k] and maps from it to the strata s (s = 1 if complier, 2 if nt, 3 if at)
+    int S[K_ymodel];
+    // Mzd maps units with Z=z and D=d to a vector of eligible Y-models indicated by nonzero elements
+    // Mzd[i] = 0 means no eligible Y-model at the ith element
+    int<lower=0, upper=K_ymodel> M00[2];
+    int<lower=0, upper=K_ymodel> M01[2];
+    int<lower=0, upper=K_ymodel> M10[2];
+    int<lower=0, upper=K_ymodel> M11[2];
+    // lengthzd is the number of eligible Y-models with Z=z and D=d
+    int length00;
+    int length01;
+    int length10;
+    int length11;
+
+    // compliers assigned to control
+    S[1] = 1;
+    // compliers assigned to treatment
+    S[2] = 1;
+    // never-takers assigned to control (and to treatment if assume ER)
+    S[3] = 2;
+
+    if (ER == 1 && K_smodel == 1) {
+        // E.g., when we assume ER and there is only one-sided noncompliance
+        // There are two eligible Y-models for those assigned control and observed control
+        length00 = 2;
+        // Eligible Y-models: the 1st Y-model for compliers assigned to control;
+        //                    the 3rd Y-model for never-takers assigned to control
+        M00[1] = 1;
+        M00[2] = 3;
+
+        length01 = 0;
+        M01[1] = 0;
+        M01[2] = 0;
+
+        length10 = 1;
+        M10[1] = 3;
+        M10[2] = 0;
+
+        length11 = 1;
+        M11[1] = 2;
+        M11[2] = 0;
+    }
+    else if (ER == 1 && K_smodel == 2) {
+        // always-takers assigned to control and treatment
+        S[4] = 3;
+
+        length00 = 2;
+        M00[1] = 1;
+        M00[2] = 3;
+
+        length01 = 1; 
+        M01[1] = 4;
+        M01[2] = 0;
+
+        length10 = 1;
+        M10[1] = 3;
+        M10[2] = 0;
+
+        length11 = 2;
+        M11[1] = 2;
+        M11[2] = 4;
+    }
+    else if (ER == 0 && K_smodel == 1) {
+        // never-takers assigned to treatment
+        S[4] = 2;
+
+        length00 = 2;
+        M00[1] = 1;
+        M00[2] = 3;
+
+        length01 = 0;
+        M01[1] = 0;
+        M01[2] = 0;
+
+        length10 = 1;
+        M10[1] = 4;
+        M10[2] = 0;
+
+        length11 = 1;
+        M11[1] = 2;
+        M11[2] = 0;
+    }
+    else if (ER == 0 && K_smodel == 2) {
+        // never-takers assigned to treatment
+        S[4] = 2;
+        // always-takers assigned to control
+        S[5] = 3;
+        // always-takers assigned to treatment
+        S[6] = 3;
+
+        length00 = 2;
+        M00[1] = 1;
+        M00[2] = 3;
+
+        length01 = 1;
+        M01[1] = 5;
+        M01[2] = 0;
+
+        length10 = 1;
+        M10[1] = 4;
+        M10[2] = 0;
+
+        length11 = 2;
+        M11[1] = 2;
+        M11[2] = 6;
+    }
+}
+
+parameters {
+    // coefficients in the Y-models (including intercept)
+    matrix[K_ymodel, P_ymodel] beta_ymodel;
+    // coefficients in the S-models (including intercept)
+    matrix[K_smodel, P_smodel] beta_smodel;
+    // dispersion parameter for negative binomial (phi)
+    real<lower=0> phi[K_ymodel];
+}
+
+model {
+    // prior
+    for (k in 1:K_smodel) {
+      for (p in 1:P_smodel) {
+        beta_smodel[k, p] ~ normal(beta_mean_smodel[k,p], beta_sd_smodel[k,p]);
+      }
+    }
+    for (k in 1:K_ymodel) {
+      for (p in 1:P_ymodel) {
+        beta_ymodel[k, p] ~ normal(beta_mean_ymodel[k,p], beta_sd_ymodel[k,p]);
+      }
+    }
+    for (k in 1:K_ymodel) {
+      phi[k] ~ gamma(phi_shape_ymodel[k], phi_rate_ymodel[k]);
+    }
+
+    if (run_estimation==1) {
+      // model
+      for (n in 1:N) {
+        int length;
+          real log_prob[K_smodel+1];
+          log_prob[1] = 0;
+          for (k in 2:(K_smodel+1)) {
+              log_prob[k] = X_smodel[n] * beta_smodel[k-1]';
+          }
+
+          if (Z[n] == 0 && D[n] == 0) {
+              length = length00;
+          }
+          else if (Z[n] == 1 && D[n] == 0) {
+              length = length10;
+          }
+          else if (Z[n] == 1 && D[n] == 1) {
+              length = length11;
+          }
+          else if (Z[n] == 0 && D[n] == 1) {
+              length = length01;
+          }
+
+          {
+      real log_l[length];
+      // Note: neg_binomial_2_log_lpmf(y | eta, phi) uses mean = exp(eta) and variance = mean + mean^2/phi
+      if (Z[n] == 0 && D[n] == 0) {
+          for (l in 1:length) {
+            log_l[l] = log_prob[S[M00[l]]] + neg_binomial_2_log_lpmf(Y[n] | X_ymodel[n] * beta_ymodel[M00[l]]', phi[M00[l]]);
+          }
+      }
+      else if (Z[n] == 1 && D[n] == 0) {
+          for (l in 1:length) {
+            log_l[l] = log_prob[S[M10[l]]] + neg_binomial_2_log_lpmf(Y[n] | X_ymodel[n] * beta_ymodel[M10[l]]', phi[M10[l]]);
+          }
+      }
+      else if (Z[n] == 1 && D[n] == 1) {
+          for (l in 1:length) {
+            log_l[l] = log_prob[S[M11[l]]] + neg_binomial_2_log_lpmf(Y[n] | X_ymodel[n] * beta_ymodel[M11[l]]', phi[M11[l]]);
+          }
+      }
+      else if (Z[n] == 0 && D[n] == 1) {
+          for (l in 1:length) {
+            log_l[l] = log_prob[S[M01[l]]] + neg_binomial_2_log_lpmf(Y[n] | X_ymodel[n] * beta_ymodel[M01[l]]', phi[M01[l]]);
+          }
+      }
+      target += log_sum_exp(log_l) - log_sum_exp(log_prob);
+          }
+      }
+    }
+}
+
+generated quantities {
+    // the probability of being in each stratum
+    vector[K_smodel+1] strata_prob;
+    // mean outcome
+    vector[K_ymodel] mean_outcome;
+    {
+        // each individual's log probability of being in each stratum
+        matrix[N, K_smodel+1] log_prob;
+        // each individual's expected means for Y-models
+        matrix[N, K_ymodel] expected_mean;
+        // weighted sum of individual's expected means for Y-models by probability of being in the relevant stratum       
+        vector[K_ymodel] weighted_outcome_sum;
+
+        log_prob[:, 1] = rep_vector(0, N);
+        log_prob[:, 2:(K_smodel+1)] = X_smodel * beta_smodel';
+        for (n in 1:N) {
+            // standardization
+            log_prob[n] -= log_sum_exp(log_prob[n]);
+        }
+
+        for (n in 1:N)
+            for (k in 1:K_ymodel)
+                // Inverse link function (exp) for Negative Binomial 2 Log
+                expected_mean[n, k] = exp(X_ymodel[n] * beta_ymodel[k]');
+
+        // aggregate individual level predictions for the average probability and outcomes
+        for (k in 1:(K_smodel+1)) {
+            strata_prob[k] = mean(exp(log_prob[:, k]));
+        }
+        for (k in 1:K_ymodel) {
+            weighted_outcome_sum[k] = mean(expected_mean[:, k] .* exp(log_prob[:, S[k]]));
+            mean_outcome[k] = weighted_outcome_sum[k] / strata_prob[S[k]];
+        }
+    }
+}

--- a/vignettes/negbin.Rmd
+++ b/vignettes/negbin.Rmd
@@ -1,0 +1,254 @@
+---
+title: "Bayesian Instrumental Variable analysis for Count Outcomes"
+author: "Yichi Zhang"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Bayesian Instrumental Variable analysis for Count Outcomes}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  eval = TRUE
+)
+```
+
+## Motivation
+
+### The Challenge with Count Outcomes
+
+In many experimental settings, the outcome of interest is a **count variable** rather than a continuous measure.
+
+Standard Instrumental Variable (IV) methods (like 2SLS) often treat outcomes as continuous. When applied to count data, linear models can be problematic because:
+
+1.  **Impossible Predictions:** They may predict negative counts.
+2.  **Skewness:** Count data is often highly right-skewed with many zeros.
+3.  **Mean-Variance Relationship:** Unlike Gaussian data, the variance of count data often increases with the mean (heteroscedasticity).
+
+### The BIVA Solution
+
+The **BIVA** package supports `y_type = "count"` to handle these cases explicitly using a **Negative Binomial** model. This approach:
+
+  * Uses a **log-link** function to ensure predictions are always non-negative.
+  * Estimates a **dispersion parameter ($\phi$)** to account for over-dispersion (where Variance \> Mean), which is common in real-world data and often violates simple Poisson assumptions.
+  * Calculates the **CACE** (Complier Average Causal Effect) on the interpretable **natural count scale** (difference in expected counts), not just the log scale.
+
+-----
+
+## Workflow Demonstration
+
+```{r start, message=FALSE, warning=FALSE}
+library(BIVA)
+library(ggplot2)
+library(MASS) # For naive GLM comparison
+```
+
+### Data Simulation
+
+We simulate data for a hypothetical experiment:
+
+  * **Z (Instrument):** A randomized email "nudge" sent to users.
+  * **D (Treatment):** Whether the user actually used the new feature.
+  * **Y (Outcome):** The number of times the user logged in over the next month (Count).
+  * **Compliance:** Two-sided noncompliance (Compliers, Never-takers, Always-takers).
+
+We generate the data using a Negative Binomial process where the treatment increases the expected count of logins for Compliers.
+
+```{r data_sim}
+set.seed(2025)
+n <- 1000
+
+# Covariates: X (Observed), U (Unobserved Confounder)
+X <- rnorm(n)
+U <- rbinom(n, 1, 0.5)
+
+# S-model: Principal Strata (1:Complier, 2:Never-taker, 3:Always-taker)
+# U affects compliance (confounding)
+true.PS <- rep(0, n)
+U1.ind <- (U == 1); U0.ind <- (U == 0)
+
+# U=1 increases prob of being a Complier
+true.PS[U1.ind] <- t(rmultinom(sum(U1.ind), 1, c(0.50, 0.40, 0.10))) %*% c(1, 2, 3)
+# U=0 decreases prob of being a Complier
+true.PS[U0.ind] <- t(rmultinom(sum(U0.ind), 1, c(0.30, 0.60, 0.10))) %*% c(1, 2, 3)
+
+# Treatment Assignment (Z) & Receipt (D)
+Z <- c(rep(0, n/2), rep(1, n/2))
+D <- rep(0, n)
+
+# Strata definitions
+c.trt.ind <- (true.PS == 1) & (Z == 1)
+c.ctrl.ind <- (true.PS == 1) & (Z == 0)
+nt.ind <- (true.PS == 2)
+at.ind <- (true.PS == 3)
+
+# D is 1 for Treated Compliers and Always-takers
+D[c.trt.ind] <- 1
+D[at.ind] <- 1
+
+# Y-model: Negative Binomial Outcome
+# Log link: log(mu) = intercept + beta*X + gamma*U
+# True Dispersion phi = 5
+phi_true <- 5
+Y <- rep(0, n)
+
+# Compliers (Control): Baseline ~ exp(2.0) = 7.4 logins
+Y[c.ctrl.ind] <- rnbinom(sum(c.ctrl.ind), 
+                         mu = exp(2.0 + 0.3*X[c.ctrl.ind] - 0.5*U[c.ctrl.ind]), 
+                         size = phi_true)
+
+# Compliers (Treated): Effect ~ exp(2.5) = 12.2 logins
+# True CACE on Count Scale ~ 12.2 - 7.4 = 4.8 additional logins
+Y[c.trt.ind] <- rnbinom(sum(c.trt.ind), 
+                        mu = exp(2.5 + 0.3*X[c.trt.ind] - 0.5*U[c.trt.ind]), 
+                        size = phi_true)
+
+# Never-takers: High baseline ~ exp(2.8) = 16.4 logins
+Y[nt.ind] <- rnbinom(sum(nt.ind), 
+                     mu = exp(2.8 + 0.3*X[nt.ind] - 0.5*U[nt.ind]), 
+                     size = phi_true)
+
+# Always-takers: Low baseline ~ exp(1.5) = 4.5 logins
+Y[at.ind] <- rnbinom(sum(at.ind), 
+                     mu = exp(1.5 + 0.3*X[at.ind] - 0.5*U[at.ind]), 
+                     size = phi_true)
+
+df <- data.frame(Y = Y, Z = Z, D = D, X = X, U = U)
+
+# Visualize the count distribution
+ggplot(df, aes(x = Y, fill = factor(D))) +
+  geom_histogram(binwidth = 1, alpha = 0.6, position = "identity") +
+  labs(title = "Distribution of Login Counts by Treatment Received", x = "Logins", fill = "Treatment (D)") +
+  theme_minimal()
+```
+
+### Naive Analysis (Biased)
+
+First, we attempt a standard generalized linear model (GLM) using Negative Binomial regression, treating the received treatment $D$ as exogenous. This ignores the unobserved confounder $U$.
+
+```{r naive_glm}
+# Naive Negative Binomial Regression (As-Treated)
+naive_model <- MASS::glm.nb(Y ~ D + X, data = df)
+summary(naive_model)$coefficients["D",,drop=FALSE]
+```
+
+The naive estimate is likely biased because $D$ is correlated with $U$ (confounding). In our simulation, users who are "Always-takers" (who take D=1) have systematically lower baseline outcomes, pulling the naive estimate down.
+
+### BIVA Analysis
+
+We now use BIVA to recover the causal effect. We specify `y_type = "count"` and provide priors for the dispersion parameter $\phi$.
+
+#### Prior Specification
+
+We use `side = 2` (Two-sided noncompliance) and `ER = 1` (Exclusion Restriction assumed).
+
+  * **Outcomes:** We estimate 4 models (Complier-Control, Complier-Treated, Never-taker, Always-taker).
+  * **Phi:** We use a Gamma prior for the dispersion parameter.
+
+<!-- end list -->
+
+```{r fit_biva}
+# Setup Priors
+K_y <- 4 # 4 Outcome models
+P_y <- 2 # Intercept + X
+
+# Weakly informative priors for coefficients
+beta_mean_y <- matrix(0, K_y, P_y)
+beta_mean_y[, 1] <- 2.0 # Intercept prior (log scale)
+beta_sd_y <- matrix(2, K_y, P_y)
+
+# Priors for Strata selection
+beta_mean_s <- matrix(0, 2, 2)
+beta_sd_s <- matrix(1, 2, 2)
+
+# Priors for Phi (Gamma shape/rate). Mean = shape/rate = 5/1 = 5.
+phi_shape <- rep(5, K_y)
+phi_rate <- rep(1, K_y)
+
+# Initialize and Fit
+ivobj <- biva$new(
+  data = df,
+  y = "Y", d = "D", z = "Z",
+  x_ymodel = c("X"),
+  x_smodel = c("X"),
+  y_type = "count",          # <--- Key Argument
+  ER = 1,
+  side = 2,
+  beta_mean_ymodel = beta_mean_y,
+  beta_sd_ymodel = beta_sd_y,
+  beta_mean_smodel = beta_mean_s,
+  beta_sd_smodel = beta_sd_s,
+  phi_shape_ymodel = phi_shape,
+  phi_rate_ymodel = phi_rate,
+  fit = TRUE,
+  iter = 2000, chains = 4, seed = 2025
+)
+```
+
+### Diagnostics
+
+We check the trace plots to ensure the MCMC chains have converged for the mean outcome parameters.
+
+```{r trace_plot, fig.align='center'}
+ivobj$tracePlot()
+```
+
+We also check for weak instruments, which can inflate variance in IV models.
+
+```{r weak_iv}
+ivobj$weakIVTest()
+```
+
+### Results and Causal Estimates
+
+We can now extract the **CACE** (Complier Average Causal Effect).
+
+**Note:** In the context of count data, BIVA calculates the CACE as the **difference in expected counts** ($E[Y(1)] - E[Y(0)]$) for the complier population. This provides a highly interpretable metric (e.g., "The feature caused 4.5 extra logins").
+
+```{r results}
+# Strata Probabilities
+ivobj$strataProbEstimate()
+
+# Point Estimate (Median CACE)
+cat("Estimated CACE (Median difference in counts): ", round(ivobj$pointEstimate(median = TRUE), 2))
+
+# Credible Interval (95%)
+ivobj$credibleInterval(width = 0.95)
+
+# Probability of Positive Effect
+ivobj$calcProb(a = 0)
+```
+
+The BIVA model successfully recovers a CACE close to the true simulated effect (approx 4.8), correcting for the bias seen in the naive analysis.
+
+### Subgroup Prediction
+
+A powerful feature of BIVA is estimating effects for specific user subgroups. For example, we can estimate the compliance probability and causal effect specifically for users with a high value of covariate $X$ (e.g., highly active users).
+
+```{r prediction}
+# Create a subgroup of users with X > 1
+high_activity_users <- df[df$X > 1, ]
+
+# Predict
+ivobj$predict(new_data = high_activity_users, name = "High_Activity")
+
+# Summarize
+print(ivobj$predSummary(name = "High_Activity"))
+```
+
+This summary tells us the specific proportion of compliers within this high-activity group and the expected lift in logins for them.
+
+-----
+
+#### Conclusion
+
+BIVA's extension to count outcomes allows for robust causal inference in settings with discrete, over-dispersed data. By modeling the data generating process explicitly with Negative Binomial distributions, we avoid the pitfalls of linear approximations and obtain interpretable results on the natural count scale.
+
+---
+
+#### BIVA
+
+Licensed under the Apache License, Version 2.0.\


### PR DESCRIPTION
This change introduces a new `y_type = "count"` option to the BIVA package, allowing for the analysis of count outcomes using a Negative Binomial model. A new Stan model (`negbin.stan`) is added, which includes a dispersion parameter (`phi`) with a Gamma prior. The `biva.R` file is updated to handle the new `y_type`, including data preparation, Stan model fitting, and prediction. A vignette (`negbin.Rmd`) is also added to demonstrate the usage and benefits of this new feature.